### PR TITLE
Improve server logging, config loading and add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Logs
+logs/
+
+# Virtual environment
+venv/
+
+# Test coverage
+htmlcov/
+.coverage
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-"# TG" 
+# TG Camera Logging Server
+
+This project provides a simple multithreaded TCP server to collect codes from cameras and store them in daily log files.
+
+## Usage
+1. Adjust camera configuration in `config.py` or provide a JSON file with the same structure (see example below).
+2. Install requirements with `pip install -r requirements.txt`.
+3. Run `python main.py` to start listening for incoming connections from cameras.
+4. Log files appear in the `logs/LINE/DATE/` directories.
+
+## Configuration
+You can store configuration in a JSON file:
+
+```json
+{
+  "camera1": {"ip": "192.168.1.101", "port": 9001, "line": "line1", "controller": "ctrl1"},
+  "camera2": {"ip": "192.168.1.102", "port": 9002, "line": "line2", "controller": "ctrl2"}
+}
+```
+
+Pass the file path in the environment variable `CAMERA_CONFIG_FILE` to override the default configuration.
+
+## Development
+- Tests are run with `pytest`.
+- Temporary files and logs are ignored via `.gitignore`.
+- Each camera connection is handled in a separate thread and writes to its own log file, so writing is thread-safe.
+

--- a/camera_handler.py
+++ b/camera_handler.py
@@ -1,13 +1,21 @@
-import socket
-from threading import Thread
-from utils import get_filename
+import logging
 from datetime import datetime
+from utils import get_filename
 
 code_memory = {}
 
+
+def cleanup_code_memory():
+    today = datetime.now().strftime("%Y-%m-%d")
+    for date in list(code_memory.keys()):
+        if date != today:
+            del code_memory[date]
+
+
 def handle_client(conn, addr, line):
     filename = get_filename(line)
-    print(f"[{line}] Прием от {addr}, файл: {filename}")
+    logging.info("[%s] Connection from %s, writing to %s", line, addr, filename)
+    cleanup_code_memory()
     with conn, open(filename, "a", encoding="utf-8") as f:
         while True:
             try:
@@ -21,7 +29,7 @@ def handle_client(conn, addr, line):
                     f.flush()
                     code_memory.setdefault(today, set()).add(code)
                 else:
-                    print(f"[{line}] Повтор: {code}")
+                    logging.info("[%s] Duplicate: %s", line, code)
             except Exception as e:
-                print(f"[{line}] Ошибка: {e}")
+                logging.error("[%s] Error: %s", line, e)
                 break

--- a/config.py
+++ b/config.py
@@ -1,4 +1,7 @@
-CAMERA_CONFIG = {
+import json
+import os
+
+DEFAULT_CONFIG = {
     "camera1": {
         "ip": "192.168.1.101",
         "port": 9001,
@@ -12,3 +15,14 @@ CAMERA_CONFIG = {
         "controller": "ctrl2"
     },
 }
+
+
+def load_config():
+    path = os.getenv("CAMERA_CONFIG_FILE")
+    if path and os.path.exists(path):
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    return DEFAULT_CONFIG
+
+
+CAMERA_CONFIG = load_config()

--- a/main.py
+++ b/main.py
@@ -1,30 +1,38 @@
 import socket
 import threading
+import logging
 from config import CAMERA_CONFIG
 from camera_handler import handle_client
 
+logging.basicConfig(level=logging.INFO, format='%(asctime)s [%(levelname)s] %(message)s')
+
+
 def start_server(ip, port, line):
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind((ip, port))
-        s.listen()
-        print(f"[{line}] Слушаю {ip}:{port} ...")
-        while True:
-            conn, addr = s.accept()
-            thread = threading.Thread(target=handle_client, args=(conn, addr, line))
-            thread.start()
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind((ip, port))
+            s.listen()
+            logging.info("[%s] Listening on %s:%s", line, ip, port)
+            while True:
+                conn, addr = s.accept()
+                thread = threading.Thread(target=handle_client, args=(conn, addr, line))
+                thread.start()
+    except OSError as e:
+        logging.error("Failed to start server for %s: %s", line, e)
+
 
 if __name__ == "__main__":
     for cam_name, cam_info in CAMERA_CONFIG.items():
         thread = threading.Thread(
             target=start_server,
             args=(cam_info["ip"], cam_info["port"], cam_info["line"]),
-            daemon=True
+            daemon=True,
         )
         thread.start()
 
-    print("Все камеры запущены. Нажмите Ctrl+C для выхода.")
+    logging.info("All cameras started. Press Ctrl+C to exit.")
     try:
         while True:
             pass
     except KeyboardInterrupt:
-        print("Завершение работы...")
+        logging.info("Shutting down...")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-python-socketio
+pytest

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,14 @@
+import sys, os; sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import json
+import os
+from importlib import reload
+import config
+
+
+def test_load_config_from_file(tmp_path, monkeypatch):
+    config_file = tmp_path / "config.json"
+    data = {"cam": {"ip": "1", "port": 1, "line": "x", "controller": "c"}}
+    config_file.write_text(json.dumps(data))
+    monkeypatch.setenv("CAMERA_CONFIG_FILE", str(config_file))
+    reload(config)
+    assert config.CAMERA_CONFIG == data

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,13 @@
+import sys, os; sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import os
+from utils import get_filename
+from datetime import datetime
+
+def test_get_filename_creates_path(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    line = "lineX"
+    path = get_filename(line)
+    assert line in path
+    date = datetime.now().strftime("%Y-%m-%d")
+    assert os.path.join("logs", line, date) in os.path.dirname(path)
+    assert os.path.exists(os.path.dirname(path))


### PR DESCRIPTION
## Summary
- add `.gitignore`
- expand project documentation in `README.md`
- support config loading from JSON file
- add logging and better error handling
- store unique codes per day and clean old entries
- simplify requirements
- add unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685901df86808329a651ecfe1814a9c1